### PR TITLE
Auto Testing multiple charts in specified folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In your workflow, set this action as a step. For example:
 ```
 | Input | Required | Description |
 | --- | ----------- | --- |
-| **path** | Yes | A path to the file/s you wish to run your Datree test against. This can be a single file or a [Glob pattern](https://www.digitalocean.com/community/tools/glob) signifying a directory. |
+| **path** | Yes | A path to the file/s you wish to run your Datree test against. This can be a single file or a [Glob pattern](https://www.digitalocean.com/community/tools/glob) signifying a directory. When `isHelmChart` is set, it will be recursive auto search in specified folder for all available helm projects. |
 | **cliArguments** | No | The desired [Datree CLI arguments](https://hub.datree.io/cli-arguments) for the policy check. In the above example, schema version 1.20.0 will be used.  |
 | **isHelmChart** | No | Specify whether the given path is a Helm chart. If this option is unused, the path will be considered as a regular yaml file. |
 | **helmArguments** | No | The Helm arguments to be used, if the path is a Helm chart. |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,104 +8,125 @@ isKustomization="$INPUT_ISKUSTOMIZATION"
 kustomizeArgs="$INPUT_KUSTOMIZEARGUMENTS"
 
 printf "datree version: "
-datree version
+if [ "$isHelmChart" = "true" ]; then
+  helm datree version
+else
+  datree version
+fi
 printf "\n"
 
 # enable recursive globbing (to support **/*.yaml for instance)
 shopt -s globstar
 
 if [ -z "$DATREE_TOKEN" ]; then
-    printf "No account token configured, see https://github.com/datreeio/action-datree for instructions\n"
-    exit 1
+  printf "No account token configured, see https://github.com/datreeio/action-datree for instructions\n"
+  exit 1
 fi
+
+function create_report() {
+  EXIT_STATUS="$?"
+
+  # Github step summary
+  RESULT_JSON_PATH="$HOME/.datree/lastPolicyCheck.json"
+  if [ ! -f "$RESULT_JSON_PATH" ]; then
+    echo ""
+    echo "No report lastPolicyCheck.json found!"
+    exit $EXIT_STATUS
+  fi
+
+  PASSED_YAML=$(jq .evaluationSummary.passedYamlValidationCount "$RESULT_JSON_PATH")
+  PASSED_K8S=$(jq .evaluationSummary.k8sValidation "$RESULT_JSON_PATH" | awk -F[\"/] '{print $2}')
+  PASSED_POLICY=$(jq .evaluationSummary.passedPolicyValidationCount "$RESULT_JSON_PATH")
+  POLICY_NAME=$(jq .policySummary.policyName "$RESULT_JSON_PATH" | awk -F[\"\"] '{print $2}')
+  TOTAL_RULES=$(jq .policySummary.totalRulesInPolicy "$RESULT_JSON_PATH")
+  CONFIGS_COUNT=$(jq .evaluationSummary.configsCount "$RESULT_JSON_PATH")
+  FILES_COUNT=$(jq .evaluationSummary.filesCount "$RESULT_JSON_PATH")
+  PASSED=$(jq .policySummary.totalPassedCount "$RESULT_JSON_PATH")
+  FAILED=$(jq .policySummary.totalRulesFailed "$RESULT_JSON_PATH")
+  SKIPPED=$(jq .policySummary.totalSkippedRules "$RESULT_JSON_PATH")
+
+  echo "<img src=\"https://raw.githubusercontent.com/datreeio/datree/main/images/datree_logo_color.svg\" width=\"350\"/>&nbsp;" >>"$GITHUB_STEP_SUMMARY"
+  echo "" >>"$GITHUB_STEP_SUMMARY"
+  echo "☸️ Want guardrails on your cluster as well? Try out our [admission webhook!](https://github.com/datreeio/admission-webhook-datree#datree-admission-webhook) ☸️&nbsp;  " >>"$GITHUB_STEP_SUMMARY"
+  echo "## Datree policy check results" >>"$GITHUB_STEP_SUMMARY"
+  echo "**Policy name:** ${POLICY_NAME}" >>"$GITHUB_STEP_SUMMARY"
+  echo "" >>"$GITHUB_STEP_SUMMARY"
+  echo "**Passed YAML validation:** ${PASSED_YAML}/${FILES_COUNT}" >>"$GITHUB_STEP_SUMMARY"
+  echo "**Passed Kubernetes schema validation:** ${PASSED_K8S}/${FILES_COUNT}" >>"$GITHUB_STEP_SUMMARY"
+  echo "**Passed policy check:** ${PASSED_POLICY}/${FILES_COUNT}" >>"$GITHUB_STEP_SUMMARY"
+
+  echo "| Enabled rules in policy ${POLICY_NAME} | ${TOTAL_RULES} |" >>"$GITHUB_STEP_SUMMARY"
+  echo "|-|-|" >>"$GITHUB_STEP_SUMMARY"
+  echo "| **Configs tested against policy** | <div align=\"center\">**${CONFIGS_COUNT}**</div> |" >>"$GITHUB_STEP_SUMMARY"
+  echo "| **Total rules evaluated** | <div align=\"center\">**$((TOTAL_RULES * FILES_COUNT))**</div> |" >>"$GITHUB_STEP_SUMMARY"
+  echo "| **Total rules skipped** | <div align=\"center\">**${SKIPPED}**</div> |" >>"$GITHUB_STEP_SUMMARY"
+  echo "| **Total rules failed** ⛔ | <div align=\"center\">**${FAILED}**</div> |" >>"$GITHUB_STEP_SUMMARY"
+  echo "| **Total rules passed** ✅ | <div align=\"center\">**${PASSED}**</div> |" >>"$GITHUB_STEP_SUMMARY"
+  echo "| **See all rules in policy** | <div align=\"center\">**[https://app.datree.io](https://app.datree.io)**</div> |" >>"$GITHUB_STEP_SUMMARY"
+  echo "" >>"$GITHUB_STEP_SUMMARY"
+  echo "" >>"$GITHUB_STEP_SUMMARY"
+
+  if [[ $FAILED -gt 0 ]]; then
+    echo "### Failed rules:" >>"$GITHUB_STEP_SUMMARY"
+    echo "" >>"$GITHUB_STEP_SUMMARY"
+  else
+    echo "### 🥳 All rules passed successfully! 🥳" >>"$GITHUB_STEP_SUMMARY"
+    exit "$EXIT_STATUS"
+  fi
+
+  NUM_OF_TESTED_FILES=$(jq ".policyValidationResults | length" "$RESULT_JSON_PATH")
+  INDEX=0
+  while [[ $INDEX -lt $NUM_OF_TESTED_FILES ]]; do
+    FILENAME=$(jq ".policyValidationResults[$INDEX] | .fileName" "$RESULT_JSON_PATH")
+    echo "**>> Filename: ${FILENAME}**" >>"$GITHUB_STEP_SUMMARY"
+    echo "" >>"$GITHUB_STEP_SUMMARY"
+
+    FAILED_IN_FILE=$(jq ".policyValidationResults[$INDEX] | .ruleResults | length" "$RESULT_JSON_PATH")
+    for ((i = 0; i < "$FAILED_IN_FILE"; i++)); do
+      # VIOLATED_RULE_ID=$(jq ".policyValidationResults[$INDEX] | .ruleResults[$i] | .identifier" "$RESULT_JSON_PATH")
+      VIOLATED_RULE_NAME=$(jq ".policyValidationResults[$INDEX] | .ruleResults[$i] | .name" "$RESULT_JSON_PATH")
+      VIOLATED_RULE_OCCURRENCES=$(jq ".policyValidationResults[$INDEX] | .ruleResults[$i] | .occurrencesDetails | length" "$RESULT_JSON_PATH")
+      VIOLATED_RULE_FAIL_MESSAGE=$(jq ".policyValidationResults[$INDEX] | .ruleResults[$i] | .messageOnFailure" "$RESULT_JSON_PATH")
+
+      echo "❌ **$VIOLATED_RULE_NAME [$VIOLATED_RULE_OCCURRENCES occurrence/s]**" >>"$GITHUB_STEP_SUMMARY"
+      for ((j = 0; j < "$VIOLATED_RULE_OCCURRENCES"; j++)); do
+        VIOLATED_RULE_METADATA_NAME=$(jq ".policyValidationResults[0] | .ruleResults[$i] | .occurrencesDetails[$j] | .metadataName" "$RESULT_JSON_PATH")
+        VIOLATED_RULE_KIND=$(jq ".policyValidationResults[0] | .ruleResults[$i] | .occurrencesDetails[$j] | .kind" "$RESULT_JSON_PATH")
+        echo "metadata.name: $VIOLATED_RULE_METADATA_NAME (kind: $VIOLATED_RULE_KIND)" >>"$GITHUB_STEP_SUMMARY"
+      done
+      echo "💡 $VIOLATED_RULE_FAIL_MESSAGE  " >>"$GITHUB_STEP_SUMMARY"
+      echo "" >>"$GITHUB_STEP_SUMMARY"
+      echo "---" >>"$GITHUB_STEP_SUMMARY"
+    done
+
+    echo "" >>"$GITHUB_STEP_SUMMARY"
+
+    ((INDEX = INDEX + 1))
+  done
+}
+
+EXIT_STATUS=0
 
 if [ "$isHelmChart" = "true" ]; then
-    helm datree test $inputpath $cliArguments -- $helmArgs
+  while read -r helmchart; do
+    dir="$(dirname "$helmchart")"
+    echo "*** Proceeding to test Helm chart: $helmchart ***"
+    set +e
+    helm datree test "$dir" $cliArguments -- $helmArgs
+    exitcode=$?
+    set -e
+    if [ "$exitcode" -gt "$EXIT_STATUS" ]; then
+      EXIT_STATUS="$exitcode"
+    fi
+    create_report
+    echo ""
+  done < <(find "$inputpath" -type f -name 'Chart.y*ml')
 elif [ "$isKustomization" = "true" ]; then
-    datree kustomize test $inputpath $cliArguments -- $kustomizeArgs
+  datree kustomize test "$inputpath" $cliArguments -- $kustomizeArgs
+  create_report
 else
-    datree test $inputpath $cliArguments  
+  datree test "$inputpath" $cliArguments
+  create_report
 fi
-
-EXIT_STATUS="$?"
-
-# Github step summary
-RESULT_JSON_PATH="$HOME/.datree/lastPolicyCheck.json"
-if [ ! -f "$RESULT_JSON_PATH" ]; then
-    exit $EXIT_STATUS
-fi
-
-PASSED_YAML=$(jq .evaluationSummary.passedYamlValidationCount "$RESULT_JSON_PATH")
-PASSED_K8S=$(jq .evaluationSummary.k8sValidation "$RESULT_JSON_PATH" | awk -F[\"/] '{print $2}' )
-PASSED_POLICY=$(jq .evaluationSummary.passedPolicyValidationCount "$RESULT_JSON_PATH")
-POLICY_NAME=$(jq .policySummary.policyName "$RESULT_JSON_PATH" | awk -F[\"\"] '{print $2}')
-TOTAL_RULES=$(jq .policySummary.totalRulesInPolicy "$RESULT_JSON_PATH")
-CONFIGS_COUNT=$(jq .evaluationSummary.configsCount "$RESULT_JSON_PATH")
-FILES_COUNT=$(jq .evaluationSummary.filesCount "$RESULT_JSON_PATH")
-PASSED=$(jq .policySummary.totalPassedCount "$RESULT_JSON_PATH")
-FAILED=$(jq .policySummary.totalRulesFailed "$RESULT_JSON_PATH")
-SKIPPED=$(jq .policySummary.totalSkippedRules "$RESULT_JSON_PATH")
-
-echo "<img src=\"https://raw.githubusercontent.com/datreeio/datree/main/images/datree_logo_color.svg\" width=\"350\"/>&nbsp;" >> $GITHUB_STEP_SUMMARY
-echo "" >> $GITHUB_STEP_SUMMARY
-echo "☸️ Want guardrails on your cluster as well? Try out our [admission webhook!](https://github.com/datreeio/admission-webhook-datree#datree-admission-webhook) ☸️&nbsp;  " >> $GITHUB_STEP_SUMMARY
-echo "## Datree policy check results" >> $GITHUB_STEP_SUMMARY
-echo "**Policy name:** $POLICY_NAME" >> $GITHUB_STEP_SUMMARY
-echo "" >> $GITHUB_STEP_SUMMARY
-echo "**Passed YAML validation:** $PASSED_YAML/$FILES_COUNT" >> $GITHUB_STEP_SUMMARY
-echo "**Passed Kubernetes schema validation:** $PASSED_K8S/$FILES_COUNT" >> $GITHUB_STEP_SUMMARY
-echo "**Passed policy check :** $PASSED_POLICY/$FILES_COUNT" >> $GITHUB_STEP_SUMMARY
-
-echo "| Enabled rules in policy $POLICY_NAME | $TOTAL_RULES |" >> $GITHUB_STEP_SUMMARY
-echo "|-|-|" >> $GITHUB_STEP_SUMMARY
-echo "| **Configs tested against policy** | <div align="center">**$CONFIGS_COUNT**</div> |" >> $GITHUB_STEP_SUMMARY
-echo "| **Total rules evaluated** | <div align="center">**$(($TOTAL_RULES*$FILES_COUNT))**</div> |" >> $GITHUB_STEP_SUMMARY
-echo "| **Total rules skipped** | <div align="center">**$SKIPPED**</div> |" >> $GITHUB_STEP_SUMMARY
-echo "| **Total rules failed** ⛔ | <div align="center">**$FAILED**</div> |" >> $GITHUB_STEP_SUMMARY
-echo "| **Total rules passed** ✅ | <div align="center">**$PASSED**</div> |" >> $GITHUB_STEP_SUMMARY
-echo "| **See all rules in policy** | <div align="center">**[https://app.datree.io](https://app.datree.io)**</div> |" >> $GITHUB_STEP_SUMMARY
-echo "" >> $GITHUB_STEP_SUMMARY
-echo "" >> $GITHUB_STEP_SUMMARY
-
-if [[ $FAILED > 0 ]]; then
-   echo "### Failed rules:" >> $GITHUB_STEP_SUMMARY
-   echo "" >> $GITHUB_STEP_SUMMARY
-else
-   echo "### 🥳 All rules passed successfully! 🥳" >> $GITHUB_STEP_SUMMARY
-   exit "$EXIT_STATUS"
-fi
-
-NUM_OF_TESTED_FILES=$(jq ".policyValidationResults | length" "$RESULT_JSON_PATH")
-INDEX=0
-while [[ $INDEX -lt $NUM_OF_TESTED_FILES ]]
-do
-   FILENAME=$(jq ".policyValidationResults[$INDEX] | .fileName" "$RESULT_JSON_PATH")
-   echo "**>> Filename: "$FILENAME"**" >> $GITHUB_STEP_SUMMARY
-   echo "" >> $GITHUB_STEP_SUMMARY
-   
-   FAILED_IN_FILE=$(jq ".policyValidationResults[$INDEX] | .ruleResults | length" "$RESULT_JSON_PATH")
-   for (( i=0; i<"$FAILED_IN_FILE"; i++ ))
-   do
-       VIOLATED_RULE_ID=$(jq ".policyValidationResults[$INDEX] | .ruleResults[$i] | .identifier" "$RESULT_JSON_PATH")
-       VIOLATED_RULE_NAME=$(jq ".policyValidationResults[$INDEX] | .ruleResults[$i] | .name" "$RESULT_JSON_PATH")
-       VIOLATED_RULE_OCCURRENCES=$(jq ".policyValidationResults[$INDEX] | .ruleResults[$i] | .occurrencesDetails | length" "$RESULT_JSON_PATH")
-       VIOLATED_RULE_FAIL_MESSAGE=$(jq ".policyValidationResults[$INDEX] | .ruleResults[$i] | .messageOnFailure" "$RESULT_JSON_PATH")
-
-       echo "❌ **"$VIOLATED_RULE_NAME" ["$VIOLATED_RULE_OCCURRENCES" occurrence/s]**" >> $GITHUB_STEP_SUMMARY
-       for (( j=0; j<"$VIOLATED_RULE_OCCURRENCES"; j++ ))
-       do 
-          VIOLATED_RULE_METADATA_NAME=$(jq ".policyValidationResults[0] | .ruleResults[$i] | .occurrencesDetails[$j] | .metadataName" "$RESULT_JSON_PATH")
-          VIOLATED_RULE_KIND=$(jq ".policyValidationResults[0] | .ruleResults[$i] | .occurrencesDetails[$j] | .kind" "$RESULT_JSON_PATH")
-          echo "metadata.name: "$VIOLATED_RULE_METADATA_NAME" (kind: "$VIOLATED_RULE_KIND")" >> $GITHUB_STEP_SUMMARY
-       done
-       echo "💡 "$VIOLATED_RULE_FAIL_MESSAGE"  " >> $GITHUB_STEP_SUMMARY
-       echo "" >> $GITHUB_STEP_SUMMARY
-       echo "---" >> $GITHUB_STEP_SUMMARY
-   done
-   
-   echo "" >> $GITHUB_STEP_SUMMARY
-   
-   ((INDEX = INDEX + 1))
-done
 
 exit $EXIT_STATUS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,11 +8,7 @@ isKustomization="$INPUT_ISKUSTOMIZATION"
 kustomizeArgs="$INPUT_KUSTOMIZEARGUMENTS"
 
 printf "datree version: "
-if [ "$isHelmChart" = "true" ]; then
-  helm datree version
-else
-  datree version
-fi
+datree version
 printf "\n"
 
 # enable recursive globbing (to support **/*.yaml for instance)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -119,10 +119,10 @@ if [ "$isHelmChart" = "true" ]; then
     echo ""
   done < <(find "$inputpath" -type f -name 'Chart.y*ml')
 elif [ "$isKustomization" = "true" ]; then
-  datree kustomize test "$inputpath" $cliArguments -- $kustomizeArgs
+  datree kustomize test $inputpath $cliArguments -- $kustomizeArgs
   create_report "$inputpath"
 else
-  datree test "$inputpath" $cliArguments
+  datree test $inputpath $cliArguments
   create_report "$inputpath"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,6 +52,7 @@ function create_report() {
   echo "" >>"$GITHUB_STEP_SUMMARY"
   echo "☸️ Want guardrails on your cluster as well? Try out our [admission webhook!](https://github.com/datreeio/admission-webhook-datree#datree-admission-webhook) ☸️&nbsp;  " >>"$GITHUB_STEP_SUMMARY"
   echo "## Datree policy check results" >>"$GITHUB_STEP_SUMMARY"
+  echo "**Source path:** ${1}" >>"$GITHUB_STEP_SUMMARY"
   echo "**Policy name:** ${POLICY_NAME}" >>"$GITHUB_STEP_SUMMARY"
   echo "" >>"$GITHUB_STEP_SUMMARY"
   echo "**Passed YAML validation:** ${PASSED_YAML}/${FILES_COUNT}" >>"$GITHUB_STEP_SUMMARY"
@@ -114,7 +115,7 @@ if [ "$isHelmChart" = "true" ]; then
     echo "*** Proceeding to test Helm chart: $helmchart ***"
     set +e
     helm datree test "$dir" $cliArguments -- $helmArgs
-    create_report
+    create_report "$dir"
     set -e
     if [ "$EXIT_STATUS_REPORT" -gt "$EXIT_STATUS" ]; then
       EXIT_STATUS="$EXIT_STATUS_REPORT"
@@ -123,10 +124,10 @@ if [ "$isHelmChart" = "true" ]; then
   done < <(find "$inputpath" -type f -name 'Chart.y*ml')
 elif [ "$isKustomization" = "true" ]; then
   datree kustomize test "$inputpath" $cliArguments -- $kustomizeArgs
-  create_report
+  create_report "$inputpath"
 else
   datree test "$inputpath" $cliArguments
-  create_report
+  create_report "$inputpath"
 fi
 
 if [ "$EXIT_STATUS_REPORT" -gt "$EXIT_STATUS" ]; then


### PR DESCRIPTION
Implemented script from here: https://github.com/datreeio/helm-datree#testing-multiple-charts
for auto search all helm project under an specified folder, to not need to add for every single helm project an own config runtime.

Also added the line:
` echo "**Source path:** ${1}" >>"$GITHUB_STEP_SUMMARY"`
to know which project was checked when multi helm project folders will be checked.

All other processes should be work as before, only helm is changed.